### PR TITLE
fix - post-message not recongised without correct message property

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ finallySystem.createUrlParams = (embedType, url, options)  => {
 
 finallySystem.createFrame = (embedType, url, options) => {
   let urlParams = finallySystem.createUrlParams(embedType, url, options)
-  let settings = Object.assign({generated: false}, options || {})
+  let settings = Object.assign({generated: false, message: 'finally-frame-load'}, options || {})
   let iframe = document.createElement('iframe', { scrolling: 'no' })
   iframe.src = `https://finallycomments.com/thread/${urlParams.category}/${urlParams.author}/${urlParams.permlink}`
   iframe.width = '100%'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finallycomments",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Forgot this was needed.
messages sends options into frame e.g `reputation: true`
ignored without message